### PR TITLE
fix: set moduleResolution to bundler

### DIFF
--- a/packages/config/react.tsconfig.json
+++ b/packages/config/react.tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "jsx": "preserve",
+    "moduleResolution": "bundler",
     "lib": ["DOM", "DOM.Iterable", "ESNext"]
   },
   "exclude": ["node_modules", ".next", ".turbo"]


### PR DESCRIPTION
## Description

This sets the `moduleResolution` in the shared TS config for React to bundler. This is the [recommended setting for use with a bundler](https://www.typescriptlang.org/tsconfig#moduleResolution) (which is used under the hood in Next)

- [x] I read the [contributing docs](CONTRIBUTING.md) (if this is your first contribution)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
