### PR TITLE
Link error fixed in Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ and visit http://localhost:4783
 
 ## 🤝 Contributors
 
-We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](CONTRIBUTING.md) before opening an issue or PR so you understand the branching strategy and local development environment.
+We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](https://github.com/tapexyz/tape/blob/0bc66629c6560ecf9cac4a8503be8619ff5eba27/.github/CONTRIBUTING.md) before opening an issue or PR so you understand the branching strategy and local development environment.
 
 <a href="https://github.com/tapexyz/tape/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=tapexyz/tape" />

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ and visit http://localhost:4783
 
 ## 🤝 Contributors
 
-We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](https://github.com/tapexyz/tape/blob/0bc66629c6560ecf9cac4a8503be8619ff5eba27/.github/CONTRIBUTING.md) before opening an issue or PR so you understand the branching strategy and local development environment.
+We love contributors! Feel free to contribute to this project but please read the [Contributing Guidelines](.github/CONTRIBUTING.md) before opening an issue or PR so you understand the branching strategy and local development environment.
 
 <a href="https://github.com/tapexyz/tape/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=tapexyz/tape" />


### PR DESCRIPTION
## Description

The link **Contributing Guidelines** has been corrected. The old one was giving a 404 error.
Right link is `https://github.com/tapexyz/tape/blob/0bc66629c6560ecf9cac4a8503be8619ff5eba27/.github/CONTRIBUTING.md`
Old link was `https://github.com/tapexyz/tape/blob/0bc66629c6560ecf9cac4a8503be8619ff5eba27/CONTRIBUTING.md`

- [x] I read the [contributing docs](CONTRIBUTING.md) (if this is your first contribution)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Minor changes in old functionality

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
