### PR TITLE
fix: oEmbed endpoint not working for external consumers (#473)

### DIFF
--- a/apps/api/src/helpers/oembed/extractOgTags.ts
+++ b/apps/api/src/helpers/oembed/extractOgTags.ts
@@ -16,13 +16,12 @@ const extractOgTags = async (document: Document) => {
 
   const urlTag = document.querySelector('meta[property="og:url"]');
   const pageUrl = urlTag
-    ? imageTag.getAttribute("content") || "https://tape.xyz"
+    ? urlTag.getAttribute("content") || "https://tape.xyz"
     : "https://tape.xyz";
 
   const iframeHTML = await constructIframe(document);
-  const html = iframeHTML;
 
-  const metadata = {
+  const metadata: Record<string, unknown> = {
     version: "1.0",
     height: 113,
     width: 200,
@@ -30,14 +29,17 @@ const extractOgTags = async (document: Document) => {
     author_name: title.match(/by\s(.*)\s•/)?.[1] || title,
     author_url: pageUrl,
     description,
-    type: "video",
+    type: iframeHTML ? "video" : "link",
     provider_name: "Tape",
     provider_url: "https://tape.xyz",
     thumbnail_height: 360,
     thumbnail_width: 480,
-    thumbnail_url: image,
-    html
+    thumbnail_url: image
   };
+
+  if (iframeHTML) {
+    metadata.html = iframeHTML;
+  }
 
   return metadata;
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
+import { cors as corsMiddleware } from "hono/cors";
 import { logger } from "hono/logger";
 
 import { cors, originLogger } from "./middlewares";
@@ -24,6 +25,10 @@ import verified from "./routes/verified";
 const app = new Hono();
 
 app.use(logger()).use(originLogger).use("*", cors);
+
+// oEmbed endpoint needs wider CORS for external consumers
+app.use("/oembed/*", corsMiddleware({ origin: "*" }));
+app.use("/oembed", corsMiddleware({ origin: "*" }));
 
 app
   .get("/", (c) => c.text("nothing to see here, visit tape.xyz"))

--- a/apps/api/src/routes/oembed.ts
+++ b/apps/api/src/routes/oembed.ts
@@ -26,6 +26,13 @@ app.get("/", zValidator("query", validationSchema), async (c) => {
     let url = reqUrlParams.get("url") as string;
     const format = reqUrlParams.get("format") as string;
 
+    if (!url) {
+      return c.json(
+        { success: false, message: "Missing required parameter: url" },
+        400
+      );
+    }
+
     if (COMMON_REGEX.TAPE_WATCH.test(url)) {
       // Fetch metatags directly from tape.xyz
       const path = new URL(url).pathname;
@@ -36,32 +43,50 @@ app.get("/", zValidator("query", validationSchema), async (c) => {
     const response = await fetch(url, {
       headers: { "User-Agent": TAPE_USER_AGENT }
     });
+
+    if (!response.ok) {
+      return c.json(
+        { success: false, message: `Failed to fetch URL: ${response.status}` },
+        400
+      );
+    }
+
     const html = await response.text();
     const { document } = parseHTML(html);
 
     const ogData = await extractOgTags(document);
 
     if (format === "json") {
+      c.header("Cache-Control", CACHE_CONTROL.FOR_ONE_WEEK);
       return c.json(ogData);
     }
 
     if (format === "xml") {
+      const escapeXml = (str: string) =>
+        String(str)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&apos;");
+
       c.res.headers.set("Content-Type", "application/xml");
+      c.header("Cache-Control", CACHE_CONTROL.FOR_ONE_WEEK);
       return c.body(`<?xml version="1.0" encoding="utf-8"?>
         <oembed>
-          <title>${ogData.title}</title>
-          <author_name>${ogData.author_name}</author_name>
-          <author_url>${ogData.author_url}</author_url>
-          <type>${ogData.type}</type>
+          <title>${escapeXml(ogData.title)}</title>
+          <author_name>${escapeXml(ogData.author_name)}</author_name>
+          <author_url>${escapeXml(ogData.author_url)}</author_url>
+          <type>${escapeXml(ogData.type)}</type>
           <height>${ogData.height}</height>
           <width>${ogData.width}</width>
-          <version>${ogData.version}</version>
-          <provider_name>${ogData.provider_name}</provider_name>
-          <provider_url>${ogData.provider_url}</provider_url>
+          <version>${escapeXml(ogData.version)}</version>
+          <provider_name>${escapeXml(ogData.provider_name)}</provider_name>
+          <provider_url>${escapeXml(ogData.provider_url)}</provider_url>
           <thumbnail_height>${ogData.thumbnail_height}</thumbnail_height>
           <thumbnail_width>${ogData.thumbnail_width}</thumbnail_width>
-          <thumbnail_url>${ogData.thumbnail_url}</thumbnail_url>
-          <html>${ogData.html}</html>
+          <thumbnail_url>${escapeXml(ogData.thumbnail_url)}</thumbnail_url>
+          <html>${escapeXml(ogData.html as string)}</html>
         </oembed>`);
     }
 
@@ -69,7 +94,7 @@ app.get("/", zValidator("query", validationSchema), async (c) => {
     return c.json({ success: true, og: ogData });
   } catch (error) {
     console.error("[OEMBED] Error:", error);
-    return c.json({ success: false, message: ERROR_MESSAGE });
+    return c.json({ success: false, message: ERROR_MESSAGE }, 500);
   }
 });
 


### PR DESCRIPTION
Fixes #473 - OEmbed not working when pasting tape.xyz links on platforms that support oEmbed.

**Bug Fixes:**
1. Fixed author_url extraction - was reading from imageTag instead of urlTag
2. Added XML entity escaping for oEmbed XML format response
3. Added validation for missing url parameter and HTTP error handling
4. Added permissive CORS for oEmbed endpoint for external consumers (iframely, Discord, etc.)
5. Changed oEmbed type to 'link' when no embed iframe can be constructed (oEmbed spec compliance)
